### PR TITLE
refactor: usar resolve em vez de join no caminho das migrações

### DIFF
--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,6 +1,7 @@
 import migrationRunner from "node-pg-migrate";
-import { join } from "node:path";
+import { resolve } from "node:path";
 import database from "infra/database.js";
+
 export default async function migrations(request, response) {
   const allowedMethods = ["GET", "POST"];
   if (!allowedMethods.includes(request.method)) {
@@ -14,7 +15,7 @@ export default async function migrations(request, response) {
     const defaultMigrationsOptions = {
       dbClient,
       dryRun: true,
-      dir: join("infra", "migrations"),
+      dir: resolve("infra", "migrations"),
       direction: "up",
       verbose: true,
       migrationsTable: "pgmigrations",


### PR DESCRIPTION
Substitui o método join por resolve para especificar o caminho das migrações. A mudança visa melhorar a resolução de caminhos, evitando possíveis problemas de compatibilidade. Isso garante maior consistência e clareza no código ao lidar com diretórios.