### PR TITLE
feat: adicionar tratamento de erro e classe de erro personalizada

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,7 @@ POSTGRES_PORT=5432
 # Variáveis de ambiente para o PostgreSQL
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=usuariodb2
+DB_USER=usuariodb
 DB_PASSWORD=suasenha
 DB_NAME=nomedb
 DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_NAME}

--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,7 @@ POSTGRES_PORT=5432
 # Variáveis de ambiente para o PostgreSQL
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=usuariodb
+DB_USER=usuariodb2
 DB_PASSWORD=suasenha
 DB_NAME=nomedb
 DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_NAME}

--- a/infra/database.js
+++ b/infra/database.js
@@ -9,7 +9,7 @@ async function query(queryObject) {
     console.log(error);
     throw error;
   } finally {
-    await client.end();
+    await client?.end();
   }
 }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,0 +1,19 @@
+export class InternalServerError extends Error {
+  constructor({ cause }) {
+    super("Um erro interno não esperado aconteceu.", {
+      cause,
+    });
+
+    this.action = "Entre em contato com o suporte";
+    this.statusCode = 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.constructor.name,
+      message: this.message,
+      action: this.action,
+      statusCode: this.statusCode,
+    };
+  }
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,52 +1,64 @@
 import database from "infra/database";
+import { InternalServerError } from "infra/errors";
 
 export default async function status(request, response) {
-  const updatedAt = new Date().toISOString();
-  const databaseVersionResult = await database.query("SHOW server_version;");
-  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+  try {
+    const updatedAt = new Date().toISOString();
+    const databaseVersionResult = await database.query("SHOW server_version;");
+    const databaseVersionValue = databaseVersionResult.rows[0].server_version;
 
-  const databaseMaxConnectionsResult = await database.query("SHOW max_connections;");
-  const databaseMaxConnectionsValue = databaseMaxConnectionsResult.rows[0].max_connections;
+    const databaseMaxConnectionsResult = await database.query("SHOW max_connections;");
+    const databaseMaxConnectionsValue = databaseMaxConnectionsResult.rows[0].max_connections;
 
-  const databaseName = process.env.DB_NAME;
-  const databaseOpendConnectionsResult = await database.query({
-    text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;",
-    values: [databaseName],
-  });
-  const databaseOpenedConnectsValues = databaseOpendConnectionsResult.rows[0].count;
+    const databaseName = process.env.DB_NAME;
+    const databaseOpendConnectionsResult = await database.query({
+      text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;",
+      values: [databaseName],
+    });
+    const databaseOpenedConnectsValues = databaseOpendConnectionsResult.rows[0].count;
 
-  // Placeholder for Cache status
-  const cacheStatus = "Not implemented";
+    // Placeholder for Cache status
+    const cacheStatus = "Not implemented";
 
-  // Placeholder for External API status
-  const externalApiStatus = "Not implemented";
+    // Placeholder for External API status
+    const externalApiStatus = "Not implemented";
 
-  // Placeholder for RabbitMQ status
-  const rabbitMQStatus = "Not implemented";
+    // Placeholder for RabbitMQ status
+    const rabbitMQStatus = "Not implemented";
 
-  // Placeholder for AWS S3 status
-  const s3Status = "Not implemented";
+    // Placeholder for AWS S3 status
+    const s3Status = "Not implemented";
 
-  response.status(200).json({
-    updatedAt: updatedAt,
-    dependencies: {
-      database: {
-        version: databaseVersionValue,
-        max_connnections: parseInt(databaseMaxConnectionsValue),
-        opened_connections: databaseOpenedConnectsValues,
+    response.status(200).json({
+      updatedAt: updatedAt,
+      dependencies: {
+        database: {
+          version: databaseVersionValue,
+          max_connnections: parseInt(databaseMaxConnectionsValue),
+          opened_connections: databaseOpenedConnectsValues,
+        },
+        cache: {
+          status: cacheStatus,
+        },
+        externalApi: {
+          status: externalApiStatus,
+        },
+        rabbitMQ: {
+          status: rabbitMQStatus,
+        },
+        s3: {
+          status: s3Status,
+        },
       },
-      cache: {
-        status: cacheStatus,
-      },
-      externalApi: {
-        status: externalApiStatus,
-      },
-      rabbitMQ: {
-        status: rabbitMQStatus,
-      },
-      s3: {
-        status: s3Status,
-      },
-    },
-  });
+    });
+  } catch (error) {
+    const publicErrorObejct = new InternalServerError({
+      cause: error,
+    });
+
+    console.log("\n erro no catch do controller");
+    console.error(publicErrorObejct);
+
+    response.status(500).json(publicErrorObejct);
+  }
 }


### PR DESCRIPTION
Adiciona a classe `InternalServerError` para padronizar erros internos e facilitar o suporte. Implementa tratamento de erro no endpoint `/api/v1/status` com logs detalhados no console. Corrige pequenas melhorias no encerramento seguro de conexões com o banco de dados.